### PR TITLE
routes.rbをroot指定に変更

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   devise_for :users
-  get '/', to: 'picup#index', as: :index
+  root to: 'picup#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
   root to: 'picup#index'
+
+  devise_for :users
 end

--- a/test/controllers/picup_controller_test.rb
+++ b/test/controllers/picup_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PicupControllerTest < ActionDispatch::IntegrationTest
   test "index" do
-    get index_path
+    get root_path
     assert_response :success
   end
 end


### PR DESCRIPTION
## 概要
routes.rbの記述方法をより良いものに変更した

## 変更箇所
* routes.rb

before
```ruby
get "/" to: ~
```
after
```ruby
root to: ~
```

## レビュー箇所
