### PR TITLE
会員登録ページ・ログインページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,5 +38,7 @@ img {
 }
 
 .picup-content {
-  padding-top: 1.8rem;
+  margin: 0;
+  padding: 0;
+  flex: 1;
 }

--- a/app/assets/stylesheets/picup.scss
+++ b/app/assets/stylesheets/picup.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the picup controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/picup/index.scss
+++ b/app/assets/stylesheets/picup/index.scss
@@ -1,0 +1,5 @@
+.picup-index {
+  .container {
+    padding:  2.0rem 1.0rem;
+  }
+}

--- a/app/assets/stylesheets/users/registrations/new.scss
+++ b/app/assets/stylesheets/users/registrations/new.scss
@@ -1,0 +1,58 @@
+.users-registrations-new {
+  width: 100%;
+  height: 100%;
+  -ms-user-select: none;
+  -moz-user-select: -moz-none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+  .container {
+    display: flex;
+    width: 100%;
+    padding: 2.0rem 1.0rem;
+    justify-content: center;
+    .register-form {
+      width: 350px;
+      max-width: 100%;
+      padding: 3.0rem 2.0rem 3.5rem 2.0rem;
+      border: 1px solid #007bff;
+      border-radius: 5px;
+      h2 {
+        margin: 0.25rem 0;
+      }
+      .picup-logo {
+        padding-bottom: 2.0rem;
+        span {
+          color: #007bff;
+          font-size: 4.0rem;
+          font-weight: bold;
+        }
+      }
+      input[type=text],
+      input[type=email],
+      input[type=password] {
+        width: 100%;
+        background: white;
+        font-size: 1.75rem;
+        margin: 0.25rem 0;
+        padding: 0.75rem 1.0rem;
+        border: 1px solid #007bff;
+        border-radius: 5px;
+      }
+      input:-webkit-autofill {
+        box-shadow: 0 0 0 1000px white inset;
+      }
+      .btn-register {
+        color: white;
+        background: #007bff;
+        font-size: 1.75rem;
+        font-weight: bold;
+        width: 100%;
+        margin: 1.0rem 0;
+        padding: 0.75rem;
+        border-color: #007bff;
+        border-radius: 5px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/users/sessions/new.scss
+++ b/app/assets/stylesheets/users/sessions/new.scss
@@ -1,0 +1,93 @@
+.users-sessions-new {
+  width: 100%;
+  height: 100%;
+  -ms-user-select: none;
+  -moz-user-select: -moz-none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+  .container {
+    display: flex;
+    width: 100%;
+    padding: 2.0rem 0.5rem;
+    justify-content: center;
+    .login-form {
+      max-width: 100%;
+      padding: 3.0rem 2.0rem 3.5rem 2.0rem;
+      border: 1px solid #007bff;
+      border-radius: 5px;
+      .picup-logo {
+        padding-bottom: 2.0rem;
+        span {
+          color: #007bff;
+          font-size: 4.0rem;
+          font-weight: bold;
+        }
+      }
+      input[type=email],
+      input[type=password] {
+        width: 250px;
+        max-width: 100%;
+        background: white;
+        font-size: 1.75rem;
+        margin: 0.25rem 0;
+        padding: 0.75rem 1.0rem;
+        border: 1px solid #007bff;
+        border-radius: 5px;
+      }
+      input:-webkit-autofill {
+        box-shadow: 0 0 0 1000px white inset;
+      }
+      .login-remember {
+        margin-top: 0.5rem;
+        .remember-me-checkbox {
+          display: none;
+        }
+        .remember-me-label {
+          cursor: pointer;
+          position: relative;
+          font-size: 1.5rem;
+          margin: 0;
+          padding-left: 27px;
+          vertical-align: middle;
+        }
+        .remember-me-label::before {
+          content: "";
+          display: block;
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 20px;
+          height: 20px;
+          margin-top: 2px;
+          border: 1px solid #007bff;
+          border-radius: 5px;
+        }
+        .remember-me-checkbox:checked+.remember-me-label::after {
+          content: "";
+          display: block;
+          position: absolute;
+          top: -4px;
+          left: 8px;
+          width: 9px;
+          height: 18px;
+          margin-top: 2px;
+          transform: rotate(40deg);
+          border-bottom: 4px solid #007bff;
+          border-right: 4px solid #007bff;
+        }
+      }
+      .btn-login {
+        color: white;
+        background: #007bff;
+        font-size: 1.75rem;
+        font-weight: bold;
+        width: 100%;
+        margin: 1.0rem 0;
+        padding: 0.75rem;
+        border-color: #007bff;
+        border-radius: 5px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/users/sessions/new.scss
+++ b/app/assets/stylesheets/users/sessions/new.scss
@@ -9,13 +9,17 @@
   .container {
     display: flex;
     width: 100%;
-    padding: 2.0rem 0.5rem;
+    padding: 2.0rem 1.0rem;
     justify-content: center;
     .login-form {
+      width: 300px;
       max-width: 100%;
       padding: 3.0rem 2.0rem 3.5rem 2.0rem;
       border: 1px solid #007bff;
       border-radius: 5px;
+      h2 {
+        margin: 0.25rem 0;
+      }
       .picup-logo {
         padding-bottom: 2.0rem;
         span {
@@ -26,8 +30,7 @@
       }
       input[type=email],
       input[type=password] {
-        width: 250px;
-        max-width: 100%;
+        width: 100%;
         background: white;
         font-size: 1.75rem;
         margin: 0.25rem 0;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
   <%= render 'layouts/header' %>
   <%= render 'layouts/flash_message' %>
 
-  <div class="container picup-content">
+  <div class="picup-content">
     <%= yield %>
   </div>
 

--- a/app/views/picup/index.html.erb
+++ b/app/views/picup/index.html.erb
@@ -1,1 +1,5 @@
-<h1>Picupへようこそ</h1>
+<div class="picup-index">
+  <div class="container">
+    <h1>Picupへようこそ</h1>
+  </div>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,39 +1,43 @@
-<h2>Sign up</h2>
+<div class="users-registrations-new">
+  <div class="container">
+    <div class="register-form">
+      <div class="picup-logo">
+        <span>Picup</span>
+      </div>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <div class="devise-error-message">
+          <%= devise_error_messages! %>
+        </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+        <div class="register-name">
+          <h2>名前</h2>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", placeholder: "名前" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+        <div class="register-screen-name">
+          <h2>ID</h2>
+          <%= f.text_field :screen_name, autofocus: true, autocomplete: "screen_name", placeholder: "ID" %>
+        </div>
+
+        <div class="register-email">
+          <h2>メールアドレス</h2>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
+        </div>
+
+        <div class="register-password">
+          <h2>パスワード</h2>
+          <div>
+            <%= f.password_field :password, autocomplete: "off", placeholder: "パスワード" %>
+          </div>
+          <div>
+            <%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "パスワード(確認)" %>
+          </div>
+        </div>
+
+        <%= f.submit "登録する", class: "btn btn-register" %>
+      <% end %>
+
+      <%= render "users/shared/links" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :screen_name %><br />
-    <%= f.text_field :screen_name, autofocus: true, autocomplete: "screen_name" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -6,11 +6,11 @@
       </div>
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="login-email">
-          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス" %>
         </div>
 
         <div class="login-password">
-          <%= f.password_field :password, autocomplete: "off" %>
+          <%= f.password_field :password, autocomplete: "off", placeholder: "パスワード" %>
         </div>
 
         <% if devise_mapping.rememberable? -%>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,29 @@
-<h2>Log in</h2>
+<div class="users-sessions-new">
+  <div class="container">
+    <div class="login-form">
+      <div class="picup-logo">
+        <span>Picup</span>
+      </div>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <div class="login-email">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+        <div class="login-password">
+          <%= f.password_field :password, autocomplete: "off" %>
+        </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-  </div>
+        <% if devise_mapping.rememberable? -%>
+          <div class="login-remember">
+            <%= f.check_box :remember_me, class: "remember-me-checkbox" %>
+            <%= f.label :remember_me, "ログイン情報を記憶する", class: "remember-me-label" %>
+          </div>
+        <% end -%>
 
-  <% if devise_mapping.rememberable? -%>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+        <%= f.submit "ログイン", class: "btn btn-login" %>
+      <% end %>
+
+      <%= render "users/shared/links" %>
     </div>
-  <% end -%>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "ログイン", new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -3,11 +3,11 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "会員登録", new_registration_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた", new_password_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
## 概要
close #25 

## 変更箇所
* 会員登録ページのデザイン

| PC | SP |
--|--
| ![](https://user-images.githubusercontent.com/20720712/36349958-1c0fb472-14d2-11e8-8662-b50a8e5fa2b4.png) | ![](https://user-images.githubusercontent.com/20720712/36349954-10e3115c-14d2-11e8-9bb5-f6fcd7ade0c6.png) |

* ログインページのデザイン

| PC | SP |
--|--
| ![](https://user-images.githubusercontent.com/20720712/36349976-6993a960-14d2-11e8-9a06-d73e6bc5832d.png) | ![](https://user-images.githubusercontent.com/20720712/36349982-73a378fe-14d2-11e8-8823-ecfd8fb17f5b.png) |

* フレームの微修正

## レビュー箇所
