### PR TITLE
パスワードリセットへのリンクを削除

### DIFF
--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードを忘れた", new_password_path(resource_name) %><br />
+  <%# link_to "パスワードを忘れた", new_password_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = { host: 'picup.herokuapp.com', protocol: 'https' }
 end


### PR DESCRIPTION
## 概要
パスワードリセットはメール送信が必要の為、ひとまずリンクを削除する

## 変更箇所
* ログイン画面などの「パスワードを忘れた」というリンクが表示されなくなる
* configにメーラーのURL設定を追加

## レビュー箇所
